### PR TITLE
Added terrible classes: Display, Player, and Map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(butimagine)
 
 find_package(sdl2 CONFIG REQUIRED)
 
-add_executable(butimagine main.cpp)
+add_executable(butimagine main.cpp World.cpp)
 
 find_path(SDL2_INCLUDE_DIR NAMES SDL.h PATH_SUFFIXES SDL2)
 target_include_directories(butimagine PRIVATE ${SDL2_INCLUDE_DIR})

--- a/World.cpp
+++ b/World.cpp
@@ -6,7 +6,7 @@ Player::Player(int _x, int _y, Map* _map) : position(_x, _y), map(_map) {
 
 void Player::MoveHoriz(int xD) {
     hasMovedOffScreen = true;
-    oldPos.x = position.x;
+    oldPos = position;
     map->Clear(*this);
     position.x += xD;
     if (position.x > MAP_WIDTH) {
@@ -17,7 +17,7 @@ void Player::MoveHoriz(int xD) {
 
 void Player::MoveVert(int yD) {
     hasMovedOffScreen = true;
-    oldPos.y = position.y;
+    oldPos = position;
     map->Clear(*this);
     position.y += yD;
     if (position.y > MAP_HEIGHT) {
@@ -45,8 +45,8 @@ void Map::SetStartMap() {
 
 // Clears the map at area covered by player
 void Map::Clear(Player player) {
-    for (int i = player.position.x; i < player.width; i++) {
-        for (int j = player.position.y; j < player.height; j++) {
+    for (int i = player.position.x; i < player.position.x + player.width; i++) {
+        for (int j = player.position.y; j < player.position.y + player.height; j++) {
             grid(i % MAP_WIDTH,j % MAP_HEIGHT) = 0;
         }
     }
@@ -54,8 +54,8 @@ void Map::Clear(Player player) {
 
 // Adds a player to the map
 void Map::Add(Player player) {
-    for (int i = player.position.x; i < player.width; i++) {
-        for (int j = player.position.y; j < player.height; j++) {
+    for (int i = player.position.x; i < player.position.x + player.width; i++) {
+        for (int j = player.position.y; j < player.position.y + player.height; j++) {
             grid(i % MAP_WIDTH, j % MAP_HEIGHT) = player.playerID;
         }
     }

--- a/World.cpp
+++ b/World.cpp
@@ -82,7 +82,7 @@ void Display::Update(Map map, bool updateScreen) {
 }
 
 void Display::Erase(Player player, bool updateScreen) {
-    SDL_Rect blankRect = {player.position.x, player.position.y, player.width, player.height};
+    SDL_Rect blankRect = {player.oldPos.x, player.oldPos.y, player.width, player.height};
     SDL_FillRect(surface, &blankRect, 0);
     if (updateScreen) {
         SDL_UpdateWindowSurface(window);

--- a/World.cpp
+++ b/World.cpp
@@ -1,0 +1,104 @@
+#include "World.hpp"
+
+Player::Player(int _x, int _y, Map* _map) : position(_x, _y), map(_map) {
+    map->Add(*this);
+}
+
+void Player::MoveHoriz(int xD) {
+    hasMovedOffScreen = true;
+    oldPos.x = position.x;
+    map->Clear(*this);
+    position.x += xD;
+    if (position.x > MAP_WIDTH) {
+        position.x = position.x % MAP_WIDTH;
+    }
+    map->Add(*this);
+}
+
+void Player::MoveVert(int yD) {
+    hasMovedOffScreen = true;
+    oldPos.y = position.y;
+    map->Clear(*this);
+    position.y += yD;
+    if (position.y > MAP_HEIGHT) {
+        position.y = position.y % MAP_HEIGHT;
+    }
+    map->Add(*this);
+}
+
+Map::Map () {
+    std::array<int, MAP_HEIGHT> inner;
+    inner.fill(0);
+    grid.fill(inner);
+}
+
+// Drawing each pixel based on each entry of grid for the map
+// will be slow compared to if we can do some SDL_FillRects, but
+// idk how to we'd do that
+void Map::SetStartMap() {
+    // random stuff to start it out
+    const int stride = 5;
+    for (int i = 0; i < MAP_WIDTH; i+=stride) {
+        for (int j = 0; j < MAP_HEIGHT; j+=stride) {
+            grid[i][j] = i*MAP_HEIGHT + j;
+        }
+    }
+}
+
+// Clears the map at area covered by player
+void Map::Clear(Player player) {
+    for (int i = player.position.x; i < player.width; i++) {
+        for (int j = player.position.y; j < player.height; j++) {
+            grid[i % MAP_WIDTH][j % MAP_HEIGHT] = 0;
+        }
+    }
+}
+
+// Adds a player to the map
+void Map::Add(Player player) {
+    for (int i = player.position.x; i < player.width; i++) {
+        for (int j = player.position.y; j < player.height; j++) {
+            grid[i % MAP_WIDTH][j % MAP_HEIGHT] = player.playerID;
+        }
+    }
+}
+
+Display::Display(SDL_Window* _w) : window(_w) {
+    surface = SDL_GetWindowSurface(window);
+}
+
+Display::~Display() {
+    SDL_DestroyWindow(window);
+}
+
+void Display::Update(Map map, bool updateScreen = true) {
+    for (int i = 0; i < MAP_WIDTH; i++) {
+        for (int j = 0; j < MAP_HEIGHT; j++) {
+            SDL_Rect point {i, j, 1, 1};
+            SDL_FillRect(surface, &point, map.grid[i][j]);
+        }
+    }
+    if (updateScreen) {
+        SDL_UpdateWindowSurface(window);
+    }
+}
+
+void Display::Erase(Player player, bool updateScreen = true) {
+    SDL_Rect blankRect = {player.position.x, player.position.y, player.width, player.height};
+    SDL_FillRect(surface, &blankRect, 0);
+    if (updateScreen) {
+        SDL_UpdateWindowSurface(window);
+    }
+}
+
+void Display::Update(Player player, bool updateScreen = true) {
+    if (player.hasMovedOffScreen) {
+        Erase(player, false /* false so we don't update in Erase and update again here*/);
+    }
+    SDL_Rect playerRect = SDL_Rect {player.position.x, player.position.y, player.width, player.height};
+    SDL_FillRect(surface, &playerRect, player.playerID);
+    player.hasMovedOffScreen = false;  // we just drew it, so it hasn't moved from what's on the screen for now
+    if (updateScreen) {
+        SDL_UpdateWindowSurface(window);
+    }
+}

--- a/World.cpp
+++ b/World.cpp
@@ -27,9 +27,7 @@ void Player::MoveVert(int yD) {
 }
 
 Map::Map () {
-    std::array<int, MAP_HEIGHT> inner;
-    inner.fill(0);
-    grid.fill(inner);
+    grid = Arr2d<int>(MAP_WIDTH, MAP_HEIGHT);
 }
 
 // Drawing each pixel based on each entry of grid for the map
@@ -40,7 +38,7 @@ void Map::SetStartMap() {
     const int stride = 5;
     for (int i = 0; i < MAP_WIDTH; i+=stride) {
         for (int j = 0; j < MAP_HEIGHT; j+=stride) {
-            grid[i][j] = i*MAP_HEIGHT + j;
+            grid(i,j) = i*MAP_HEIGHT + j;
         }
     }
 }
@@ -49,7 +47,7 @@ void Map::SetStartMap() {
 void Map::Clear(Player player) {
     for (int i = player.position.x; i < player.width; i++) {
         for (int j = player.position.y; j < player.height; j++) {
-            grid[i % MAP_WIDTH][j % MAP_HEIGHT] = 0;
+            grid(i % MAP_WIDTH,j % MAP_HEIGHT) = 0;
         }
     }
 }
@@ -58,7 +56,7 @@ void Map::Clear(Player player) {
 void Map::Add(Player player) {
     for (int i = player.position.x; i < player.width; i++) {
         for (int j = player.position.y; j < player.height; j++) {
-            grid[i % MAP_WIDTH][j % MAP_HEIGHT] = player.playerID;
+            grid(i % MAP_WIDTH, j % MAP_HEIGHT) = player.playerID;
         }
     }
 }
@@ -71,11 +69,11 @@ Display::~Display() {
     SDL_DestroyWindow(window);
 }
 
-void Display::Update(Map map, bool updateScreen = true) {
+void Display::Update(Map map, bool updateScreen) {
     for (int i = 0; i < MAP_WIDTH; i++) {
         for (int j = 0; j < MAP_HEIGHT; j++) {
             SDL_Rect point {i, j, 1, 1};
-            SDL_FillRect(surface, &point, map.grid[i][j]);
+            SDL_FillRect(surface, &point, map.grid(i,j));
         }
     }
     if (updateScreen) {
@@ -83,7 +81,7 @@ void Display::Update(Map map, bool updateScreen = true) {
     }
 }
 
-void Display::Erase(Player player, bool updateScreen = true) {
+void Display::Erase(Player player, bool updateScreen) {
     SDL_Rect blankRect = {player.position.x, player.position.y, player.width, player.height};
     SDL_FillRect(surface, &blankRect, 0);
     if (updateScreen) {
@@ -91,7 +89,7 @@ void Display::Erase(Player player, bool updateScreen = true) {
     }
 }
 
-void Display::Update(Player player, bool updateScreen = true) {
+void Display::Update(Player player, bool updateScreen) {
     if (player.hasMovedOffScreen) {
         Erase(player, false /* false so we don't update in Erase and update again here*/);
     }

--- a/World.hpp
+++ b/World.hpp
@@ -1,5 +1,9 @@
-#include <array>
+#pragma once
+
+#define SDL_MAIN_HANDLED 1
 #include "SDL.h"
+
+#include "util.hpp"
 
 #define MAP_WIDTH 640
 #define MAP_HEIGHT 480
@@ -31,16 +35,20 @@ struct Player {
     int height = 10;
     int health = 100;
     int runEnergy = 100;
-    int playerID = 333; //using this as their color
+    int playerID = INT_MAX/2; //using this as their color
     
     Map* map;
+
+    Player::Player(int _x, int _y, Map* _map);
+
+    void Player::MoveHoriz(int xD);
+    void Player::MoveVert(int yD);
 
     friend struct Display;
 };
 
 struct Map {
-    typedef std::array<std::array<int, MAP_HEIGHT>, MAP_WIDTH> arr2d;
-    arr2d grid;
+    Arr2d<int> grid;
 
     // npcs
 

--- a/World.hpp
+++ b/World.hpp
@@ -1,0 +1,76 @@
+#include <array>
+#include "SDL.h"
+
+#define MAP_WIDTH 640
+#define MAP_HEIGHT 480
+
+struct Map;
+struct Display;
+
+struct GridPos {
+    int x, y;
+
+    inline GridPos() : x(0), y(0) {}
+    inline GridPos(int _x, int _y) : x(_x), y(_y) {}
+};
+
+struct Player {
+    private:
+    // Currently the way it works is player has 2 positions.
+    // the second position is to store the players updated position
+    // That way we can keep track of the old position and remove it from the screen
+    // There will be problems if you move the player multiple times without drawing to the screen
+    // Because then the Display::Update(Player) func will "erase" pixels thinking the player
+    // was there, however, the pixels were never drawn to the display
+    bool hasMovedOffScreen = false;
+
+    public:
+    GridPos position;
+    GridPos oldPos;
+    int width = 10;
+    int height = 10;
+    int health = 100;
+    int runEnergy = 100;
+    int playerID = 333; //using this as their color
+    
+    Map* map;
+
+    friend struct Display;
+};
+
+struct Map {
+    typedef std::array<std::array<int, MAP_HEIGHT>, MAP_WIDTH> arr2d;
+    arr2d grid;
+
+    // npcs
+
+    // walls
+
+    Map ();
+
+    // Drawing each pixel based on each entry of grid for the map
+    // will be slow compared to if we can do some SDL_FillRects, but
+    // idk how to we'd do that
+    void SetStartMap();
+
+    // Clears the map at area covered by player
+    void Clear(Player player);
+
+    // Adds a player to the map
+    void Add(Player player);
+};
+
+struct Display {
+    SDL_Window* window = nullptr;
+    SDL_Surface* surface = nullptr;
+
+    Display(SDL_Window* _w);
+
+    ~Display();
+
+    void Update(Map map, bool updateScreen = true);
+
+    void Erase(Player player, bool updateScreen = true);
+
+    void Update(Player player, bool updateScreen = true);
+};

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,3 @@
-#include <array>
 #include <cstdio>
 #include <windows.h>
 
@@ -6,162 +5,6 @@
 #include "SDL.h"
 
 #include "World.hpp"
-
-
-// what to do first
-
-// i need a map
-
-
-// struct Map;
-
-// struct GridPos {
-//     int x, y;
-
-//     GridPos() : x(0), y(0) {}
-//     GridPos(int _x, int _y) : x(_x), y(_y) {}
-// };
-
-// struct Player {
-//     private:
-//     // Currently the way it works is player has 2 positions.
-//     // the second position is to store the players updated position
-//     // That way we can keep track of the old position and remove it from the screen
-//     // There will be problems if you move the player multiple times without drawing to the screen
-//     // Because then the Display::Update(Player) func will "erase" pixels thinking the player
-//     // was there, however, the pixels were never drawn to the display
-//     bool hasMovedOffScreen = false;
-
-//     public:
-//     GridPos position;
-//     GridPos oldPos;
-//     int width = 10;
-//     int height = 10;
-//     int health = 100;
-//     int runEnergy = 100;
-//     int playerID = 333; //using this as their color
-    
-//     Map* map;
-
-//     Player(int _x, int _y, Map* _map) : position(_x, _y), map(_map) {
-//         map->Add(*this);
-//     }
-
-//     void MoveHoriz(int xD) {
-//         hasMovedOffScreen = true;
-//         oldPos.x = position.x;
-//         map->Clear(*this);
-//         position.x += xD;
-//         if (position.x > MAP_WIDTH) {
-//             position.x = position.x % MAP_WIDTH;
-//         }
-//         map->Add(*this);
-//     }
-
-//     void MoveVert(int yD) {
-//         hasMovedOffScreen = true;
-//         oldPos.y = position.y;
-//         map->Clear(*this);
-//         position.y += yD;
-//         if (position.y > MAP_HEIGHT) {
-//             position.y = position.y % MAP_HEIGHT;
-//         }
-//         map->Add(*this);
-//     }
-
-//     friend struct Display;
-// };
-
-// struct Map {
-//     typedef std::array<std::array<int, MAP_HEIGHT>, MAP_WIDTH> arr2d;
-//     arr2d grid;
-
-//     // npcs
-
-//     // walls
-
-//     Map () {
-//         std::array<int, MAP_HEIGHT> inner;
-//         inner.fill(0);
-//         grid.fill(inner);
-//     }
-
-//     // Drawing each pixel based on each entry of grid for the map
-//     // will be slow compared to if we can do some SDL_FillRects, but
-//     // idk how to we'd do that
-//     void SetStartMap() {
-//         // random stuff to start it out
-//         const int stride = 5;
-//         for (int i = 0; i < MAP_WIDTH; i+=stride) {
-//             for (int j = 0; j < MAP_HEIGHT; j+=stride) {
-//                 grid[i][j] = i*MAP_HEIGHT + j;
-//             }
-//         }
-//     }
-
-//     // Clears the map at area covered by player
-//     void Clear(Player player) {
-//         for (int i = player.position.x; i < player.width; i++) {
-//             for (int j = player.position.y; j < player.height; j++) {
-//                 grid[i % MAP_WIDTH][j % MAP_HEIGHT] = 0;
-//             }
-//         }
-//     }
-
-//     // Adds a player to the map
-//     void Add(Player player) {
-//         for (int i = player.position.x; i < player.width; i++) {
-//             for (int j = player.position.y; j < player.height; j++) {
-//                 grid[i % MAP_WIDTH][j % MAP_HEIGHT] = player.playerID;
-//             }
-//         }
-//     }
-// };
-
-// struct Display {
-//     SDL_Window* window = nullptr;
-//     SDL_Surface* surface = nullptr;
-
-//     Display(SDL_Window* _w) : window(_w) {
-//         surface = SDL_GetWindowSurface(window);
-//     }
-
-//     ~Display() {
-//         SDL_DestroyWindow(window);
-//     }
-
-//     void Update(Map map, bool updateScreen = true) {
-//         for (int i = 0; i < MAP_WIDTH; i++) {
-//             for (int j = 0; j < MAP_HEIGHT; j++) {
-//                 SDL_Rect point {i, j, 1, 1};
-//                 SDL_FillRect(surface, &point, map.grid[i][j]);
-//             }
-//         }
-//         if (updateScreen) {
-//             SDL_UpdateWindowSurface(window);
-//         }
-//     }
-
-//     void Erase(Player player, bool updateScreen = true) {
-//         SDL_Rect blankRect = {player.position.x, player.position.y, player.width, player.height};
-//         SDL_FillRect(surface, &blankRect, 0);
-//         if (updateScreen) {
-//             SDL_UpdateWindowSurface(window);
-//         }
-//     }
-
-//     void Update(Player player, bool updateScreen = true) {
-//         if (player.hasMovedOffScreen) {
-//             Erase(player, false /* false so we don't update in Erase and update again here*/);
-//         }
-//         SDL_Rect playerRect = SDL_Rect {player.position.x, player.position.y, player.width, player.height};
-//         SDL_FillRect(surface, &playerRect, player.playerID);
-//         player.hasMovedOffScreen = false;  // we just drew it, so it hasn't moved from what's on the screen for now
-//         if (updateScreen) {
-//             SDL_UpdateWindowSurface(window);
-//         }
-//     }
-// };
 
 void init() {
     SDL_Init(SDL_INIT_EVERYTHING);
@@ -173,8 +16,7 @@ void cleanup() {
 
 int main(int argc, char* argv[]) {
     init();
-
-    Map map();
+    Map map;
     map.SetStartMap();
 
     // not sure how I feel about the map updating through the player class but fuck it right
@@ -186,16 +28,21 @@ int main(int argc, char* argv[]) {
     }
 
     Display display(win);
+    printf("A\n");
 
     display.Update(map); // first draw of the map the screen (should include player initial pos)
+    printf("A\n");
     Sleep(1500);
+    printf("A\n");
+    printf("Z\n");
 
-    player1.MoveHoriz(20);
+    player1.MoveHoriz(50);
     display.Update(player1);
     Sleep(1500);
 
     player1.MoveVert(40);
     display.Update(player1);
+    Sleep(1500);
 
     cleanup();
     return 0;
@@ -204,7 +51,7 @@ int main(int argc, char* argv[]) {
 
 // stuff I made, and stopped using, but don't wanna throw away yet so I can reference it
 namespace Junkyard {
-    void DrawPlayer(Player player, SDL_Surface* winSurface, ) {
+    void DrawPlayer(Player player, SDL_Surface* winSurface) {
         SDL_Rect rect = SDL_Rect {player.position.x, player.position.y, player.width, player.height};
         SDL_FillRect( winSurface, &rect, SDL_MapRGB( winSurface->format, 255, 90, 120 ));
     }

--- a/main.cpp
+++ b/main.cpp
@@ -1,71 +1,222 @@
-#include <vector>
+#include <array>
 #include <cstdio>
 #include <windows.h>
 
 #define SDL_MAIN_HANDLED 1
 #include "SDL.h"
 
+#include "World.hpp"
+
 
 // what to do first
 
 // i need a map
-class Map {
-    typedef std::vector<std::vector<int>> vector2d;
-    vector2d grid;
-    // npcs
 
-    // walls
-};
 
-struct GridPos {
-    int i, j;
+// struct Map;
 
-    GridPos() : i(0), j(0) {}
-    GridPos(int _i, int _j) : i(_i), j(_i) {}
-};
+// struct GridPos {
+//     int x, y;
 
-class Player {
-    GridPos position;
-    int health;
-    int runEnergy;
+//     GridPos() : x(0), y(0) {}
+//     GridPos(int _x, int _y) : x(_x), y(_y) {}
+// };
 
-    Player() : position(0, 0), health(0), runEnergy(0) {}
-};
+// struct Player {
+//     private:
+//     // Currently the way it works is player has 2 positions.
+//     // the second position is to store the players updated position
+//     // That way we can keep track of the old position and remove it from the screen
+//     // There will be problems if you move the player multiple times without drawing to the screen
+//     // Because then the Display::Update(Player) func will "erase" pixels thinking the player
+//     // was there, however, the pixels were never drawn to the display
+//     bool hasMovedOffScreen = false;
+
+//     public:
+//     GridPos position;
+//     GridPos oldPos;
+//     int width = 10;
+//     int height = 10;
+//     int health = 100;
+//     int runEnergy = 100;
+//     int playerID = 333; //using this as their color
+    
+//     Map* map;
+
+//     Player(int _x, int _y, Map* _map) : position(_x, _y), map(_map) {
+//         map->Add(*this);
+//     }
+
+//     void MoveHoriz(int xD) {
+//         hasMovedOffScreen = true;
+//         oldPos.x = position.x;
+//         map->Clear(*this);
+//         position.x += xD;
+//         if (position.x > MAP_WIDTH) {
+//             position.x = position.x % MAP_WIDTH;
+//         }
+//         map->Add(*this);
+//     }
+
+//     void MoveVert(int yD) {
+//         hasMovedOffScreen = true;
+//         oldPos.y = position.y;
+//         map->Clear(*this);
+//         position.y += yD;
+//         if (position.y > MAP_HEIGHT) {
+//             position.y = position.y % MAP_HEIGHT;
+//         }
+//         map->Add(*this);
+//     }
+
+//     friend struct Display;
+// };
+
+// struct Map {
+//     typedef std::array<std::array<int, MAP_HEIGHT>, MAP_WIDTH> arr2d;
+//     arr2d grid;
+
+//     // npcs
+
+//     // walls
+
+//     Map () {
+//         std::array<int, MAP_HEIGHT> inner;
+//         inner.fill(0);
+//         grid.fill(inner);
+//     }
+
+//     // Drawing each pixel based on each entry of grid for the map
+//     // will be slow compared to if we can do some SDL_FillRects, but
+//     // idk how to we'd do that
+//     void SetStartMap() {
+//         // random stuff to start it out
+//         const int stride = 5;
+//         for (int i = 0; i < MAP_WIDTH; i+=stride) {
+//             for (int j = 0; j < MAP_HEIGHT; j+=stride) {
+//                 grid[i][j] = i*MAP_HEIGHT + j;
+//             }
+//         }
+//     }
+
+//     // Clears the map at area covered by player
+//     void Clear(Player player) {
+//         for (int i = player.position.x; i < player.width; i++) {
+//             for (int j = player.position.y; j < player.height; j++) {
+//                 grid[i % MAP_WIDTH][j % MAP_HEIGHT] = 0;
+//             }
+//         }
+//     }
+
+//     // Adds a player to the map
+//     void Add(Player player) {
+//         for (int i = player.position.x; i < player.width; i++) {
+//             for (int j = player.position.y; j < player.height; j++) {
+//                 grid[i % MAP_WIDTH][j % MAP_HEIGHT] = player.playerID;
+//             }
+//         }
+//     }
+// };
+
+// struct Display {
+//     SDL_Window* window = nullptr;
+//     SDL_Surface* surface = nullptr;
+
+//     Display(SDL_Window* _w) : window(_w) {
+//         surface = SDL_GetWindowSurface(window);
+//     }
+
+//     ~Display() {
+//         SDL_DestroyWindow(window);
+//     }
+
+//     void Update(Map map, bool updateScreen = true) {
+//         for (int i = 0; i < MAP_WIDTH; i++) {
+//             for (int j = 0; j < MAP_HEIGHT; j++) {
+//                 SDL_Rect point {i, j, 1, 1};
+//                 SDL_FillRect(surface, &point, map.grid[i][j]);
+//             }
+//         }
+//         if (updateScreen) {
+//             SDL_UpdateWindowSurface(window);
+//         }
+//     }
+
+//     void Erase(Player player, bool updateScreen = true) {
+//         SDL_Rect blankRect = {player.position.x, player.position.y, player.width, player.height};
+//         SDL_FillRect(surface, &blankRect, 0);
+//         if (updateScreen) {
+//             SDL_UpdateWindowSurface(window);
+//         }
+//     }
+
+//     void Update(Player player, bool updateScreen = true) {
+//         if (player.hasMovedOffScreen) {
+//             Erase(player, false /* false so we don't update in Erase and update again here*/);
+//         }
+//         SDL_Rect playerRect = SDL_Rect {player.position.x, player.position.y, player.width, player.height};
+//         SDL_FillRect(surface, &playerRect, player.playerID);
+//         player.hasMovedOffScreen = false;  // we just drew it, so it hasn't moved from what's on the screen for now
+//         if (updateScreen) {
+//             SDL_UpdateWindowSurface(window);
+//         }
+//     }
+// };
 
 void init() {
-    printf("Doing SDL_Init\n");
     SDL_Init(SDL_INIT_EVERYTHING);
 }
 
-// int main() {
-//     init();
-//     return 0;
-// }
+void cleanup() {
+    SDL_Quit();
+}
 
 int main(int argc, char* argv[]) {
     init();
 
-    SDL_Window* win = SDL_CreateWindow( "my window", 100, 100, 640, 480, SDL_WINDOW_SHOWN );
+    Map map();
+    map.SetStartMap();
 
+    // not sure how I feel about the map updating through the player class but fuck it right
+    Player player1(MAP_WIDTH/2, MAP_HEIGHT/2, &map);
+
+    SDL_Window* win = SDL_CreateWindow( "my window", 100, 100, MAP_WIDTH, MAP_HEIGHT, SDL_WINDOW_SHOWN );
     if ( !win ) {
         printf("Failed to create a window! Error: %s\n", SDL_GetError());
     }
 
-    SDL_Surface* winSurface = SDL_GetWindowSurface( win );
+    Display display(win);
 
-    // do drawing
-    SDL_FillRect( winSurface, NULL, SDL_MapRGB( winSurface->format, 90, 255, 120 ));
+    display.Update(map); // first draw of the map the screen (should include player initial pos)
+    Sleep(1500);
 
-    SDL_UpdateWindowSurface( win );
+    player1.MoveHoriz(20);
+    display.Update(player1);
+    Sleep(1500);
 
-    printf("starting sleep\n");
-    Sleep(5000);
-    printf("OUT OF sleep\n");
+    player1.MoveVert(40);
+    display.Update(player1);
 
-    SDL_DestroyWindow( win );
-    win = NULL;
-    winSurface = NULL;
-
-    SDL_Quit();
+    cleanup();
     return 0;
 }
+
+
+// stuff I made, and stopped using, but don't wanna throw away yet so I can reference it
+namespace Junkyard {
+    void DrawPlayer(Player player, SDL_Surface* winSurface, ) {
+        SDL_Rect rect = SDL_Rect {player.position.x, player.position.y, player.width, player.height};
+        SDL_FillRect( winSurface, &rect, SDL_MapRGB( winSurface->format, 255, 90, 120 ));
+    }
+
+    void InitSurface(Player player1, SDL_Surface* winSurface) {
+        const int stride = 5;
+        for (int i = 0; i < MAP_WIDTH; i+=stride) {
+            for (int j = 0; j < MAP_HEIGHT; j+=stride) {
+                SDL_Rect rect {i, j, stride, stride};
+                SDL_FillRect(winSurface, &rect, i*MAP_HEIGHT + j);
+            }
+        }
+        DrawPlayer(player1, winSurface);
+    }
+};

--- a/util.cpp
+++ b/util.cpp
@@ -1,0 +1,8 @@
+#include "util.hpp"
+#include <assert.h>
+
+template<typename T>
+T Arr2d::operator()<T<(size_t i, size_t j) {
+    assert(i < iMax && j < jMAX);
+    return arr[jMax*i + j];
+}

--- a/util.hpp
+++ b/util.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <vector>
+#include <assert.h>
+
+// i mighta fucked up the orientation for this not sure
+
+template<typename T>
+struct Arr2d {
+    size_t size;
+    size_t iMax;
+    size_t jMax;
+    std::vector<T> arr;
+
+    Arr2d() : iMax(0), jMax(0), size(0), arr(0) {}
+
+    Arr2d(size_t _i, size_t _j) : iMax(_i), jMax(_j), size(_i*_j), arr(_i*_j) {}
+
+    T& operator()(size_t i, size_t j) {
+        assert(i < iMax && j < jMax);
+        return arr[jMax*i + j];
+    }
+
+};


### PR DESCRIPTION
Added these classes to interact with the graphics functions. They're in the World.cpp/hpp files.
I also added an Arr2d class in util.cpp that Map uses. It's just a vector that pretends to be a 2d vector cause 2d vectors in C++ kinda ass.

Anyway,

Map is a class with said 2darray (variable is called grid within Map class), representing the world in the game at this point. Each point in the map corresponds to a pixel on the actual window that pops up.

Player is a class with a x,y position, representing where it should be on the map, as well as width and height to give it dimensions. It also has a reference to the map so that each player can automatically update the map object when the player coordinates change.

Display is a class I made to wrap around some of the graphics functions that are gross. It is created from an SDL_Window that you get from one of the basic library functions, SDL_CreateWindow. You can give a Display object a Map (myDisplay.Update(myMap)), and it will update the window on the screen to what the map object contains, or you can give it a player, which will draw that player on the screen (and erase its old position if it has moved since the last draw to screen)